### PR TITLE
Use end event rather than overwriting ctx.res.end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-http-handler",
   "description": "Allows integration of an existing http handler into the fusion request lifecycle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": "fusionjs/fusion-plugin-http-handler",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-http-handler",
   "description": "Allows integration of an existing http handler into the fusion request lifecycle",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "repository": "fusionjs/fusion-plugin-http-handler",
   "files": [
     "dist",

--- a/src/__tests__/express-send.node.js
+++ b/src/__tests__/express-send.node.js
@@ -1,0 +1,45 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import test from 'tape-cup';
+import App from 'fusion-core';
+import express from 'express';
+import {HttpHandlerToken} from '../tokens.js';
+import HttpHandlerPlugin from '../server.js';
+import {startServer} from '../test-util.js';
+
+test('http handler with express using send', async t => {
+  const app = new App('test', () => 'test');
+  app.register(HttpHandlerPlugin);
+  const expressApp = express();
+  expressApp.get('/express', (req, res) => {
+    res.send('OK');
+  });
+  app.register(HttpHandlerToken, expressApp);
+  app.middleware((ctx, next) => {
+    ctx.req.secure = false;
+    ctx.body = 'hit fallthrough';
+    return next();
+  });
+
+  const {server, request} = await startServer(app.callback());
+
+  t.equal(await request('/express'), 'OK', 'express routes can send responses');
+  t.equal(
+    await request('/fallthrough'),
+    'hit fallthrough',
+    'express routes can delegate back to koa'
+  );
+  t.equal(
+    await request('/fallthrough'),
+    'hit fallthrough',
+    'express routes can delegate back to koa'
+  );
+  server.close();
+  t.end();
+});

--- a/src/__tests__/express-send.node.js
+++ b/src/__tests__/express-send.node.js
@@ -27,6 +27,7 @@ test('http handler with express using send', async t => {
     } else {
       t.equal(ctx.res.statusCode, 404, 'non express routes default to 404');
     }
+    // $FlowFixMe
     ctx.req.secure = false;
     ctx.body = 'hit fallthrough';
     return next();

--- a/src/__tests__/express-send.node.js
+++ b/src/__tests__/express-send.node.js
@@ -22,6 +22,11 @@ test('http handler with express using send', async t => {
   });
   app.register(HttpHandlerToken, expressApp);
   app.middleware((ctx, next) => {
+    if (ctx.url === '/express') {
+      t.equal(ctx.res.statusCode, 200, 'express route sets status code');
+    } else {
+      t.equal(ctx.res.statusCode, 404, 'non express routes default to 404');
+    }
     ctx.req.secure = false;
     ctx.body = 'hit fallthrough';
     return next();

--- a/src/server.js
+++ b/src/server.js
@@ -9,10 +9,8 @@
 /* eslint-env node */
 
 import {createPlugin} from 'fusion-core';
-import {HttpHandlerToken} from './tokens.js';
-
 import type {FusionPlugin} from 'fusion-core';
-
+import {HttpHandlerToken} from './tokens.js';
 import type {DepsType, ServiceType} from './types.js';
 
 const plugin =
@@ -29,19 +27,20 @@ const plugin =
           return next();
         }
         return new Promise((resolve, reject) => {
-          const oldEnd = ctx.res.end.bind(ctx.res);
-          // $FlowFixMe
-          ctx.res.end = (data, encoding, cb) => {
+          const {req, res} = ctx;
+          const listener = () => {
             ctx.respond = false;
-            return next()
-              .then(resolve)
-              .then(() => {
-                oldEnd(data, encoding, cb);
-              });
+            return next().then(resolve);
           };
-          handler(ctx.req, ctx.res, () => {
-            // $FlowFixMe
-            ctx.res.end = oldEnd;
+          res.on('end', listener);
+          handler(req, res, () => {
+            // Express mutates the req object to make this property non-writable.
+            // We need to make it writable because other plugins (like koa-helmet) will set it
+            Object.defineProperty(req, 'secure', {
+              value: req.secure,
+              writable: true,
+            });
+            res.removeListener('end', listener);
             return next()
               .then(resolve)
               .catch(reject);

--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,9 @@ const plugin =
           function done() {
             // Express mutates the req object to make this property non-writable.
             // We need to make it writable because other plugins (like koa-helmet) will set it
+            // $FlowFixMe
             Object.defineProperty(req, 'secure', {
+              // $FlowFixMe
               value: req.secure,
               writable: true,
             });


### PR DESCRIPTION
This simplifies the logic for knowing when a response is sent. Also fixes a bug where express and koa-helmet clash with respect to ctx.req.secure.