### PR TITLE
Release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-http-handler",
   "description": "Allows integration of an existing http handler into the fusion request lifecycle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "fusionjs/fusion-plugin-http-handler",
   "files": [
     "dist",


### PR DESCRIPTION
- Use end event rather than overwriting ctx.res.end ([#43](https://github.com/fusionjs/fusion-plugin-http-handler/pull/43))
- Update dependency eslint-plugin-prettier to v2.6.2 ([#27](https://github.com/fusionjs/fusion-plugin-http-handler/pull/27))