### PR TITLE
Make browser export null for better run-time check

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -10,6 +10,6 @@ import test from 'tape-cup';
 import browserPlugin from '../browser.js';
 
 test('browser exports null', t => {
-  t.deepEqual(browserPlugin, {});
+  t.deepEqual(browserPlugin, null);
   t.end();
 });

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,4 +8,4 @@
 import type {FusionPlugin} from 'fusion-core';
 import type {DepsType, ServiceType} from './types.js';
 
-export default (({}: any): FusionPlugin<DepsType, ServiceType>);
+export default ((null: any): FusionPlugin<DepsType, ServiceType>);


### PR DESCRIPTION
This will generate non-cryptic error messages for invalid plugin registrations