### PR TITLE
Fix issues with sending headers after response and body parser compatibility

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,8 +34,11 @@ const plugin =
           ctx.res.statusCode = 200;
           const listener = () => {
             // Makes koa-bodyparser compatible with bodyparser
+            // $FlowFixMe
             req._body = true;
+            // $FlowFixMe
             req.body = ctx.request.body;
+            // $FlowFixMe
             res.setHeader = () => {};
             ctx.respond = false;
             return done();

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,10 @@ const plugin =
           const prevStatusCode = ctx.res.statusCode;
           ctx.res.statusCode = 200;
           const listener = () => {
+            // Makes koa-bodyparser compatible with bodyparser
+            req._body = true;
+            req.body = ctx.request.body;
+            res.setHeader = () => {};
             ctx.respond = false;
             return done();
           };


### PR DESCRIPTION
This fixes compatibility issues with koa-bodyparser and fixes an issue where an error was thrown if a plugin tries to set headers after the response was sent.