### PR TITLE
Update handler to run after await next and handle errors from express app

### DIFF
--- a/src/__tests__/express-get.node.js
+++ b/src/__tests__/express-get.node.js
@@ -35,13 +35,6 @@ test('http handler with express', async t => {
 
   app.register(HttpHandlerToken, expressApp);
 
-  app.middleware((ctx, next) => {
-    if (!ctx.body) {
-      ctx.body = 'hit fallthrough';
-    }
-    return next();
-  });
-
   const {server, request} = await startServer(app.callback());
 
   t.equal(
@@ -57,16 +50,6 @@ test('http handler with express', async t => {
 
   t.equal(await request('/lol'), 'OK', 'express routes can send responses');
   t.equal(hitExpressMiddleware, true, 'express middleware hit');
-
-  hitExpressMiddleware = false;
-
-  t.equal(
-    await request('/fallthrough'),
-    'hit fallthrough',
-    'express routes can delegate back to koa'
-  );
-  t.equal(hitExpressMiddleware, true, 'express middleware hit');
-
   server.close();
   t.end();
 });

--- a/src/__tests__/express-pipe.node.js
+++ b/src/__tests__/express-pipe.node.js
@@ -22,17 +22,16 @@ test('http handler with express', async t => {
   const proxyServer = http.createServer((req, res) => res.end('Proxy OK'));
   const port2 = await getPort();
   await new Promise(resolve => proxyServer.listen(port, resolve));
+  app.middleware(async (ctx, next) => {
+    await next();
+    t.equal(ctx.respond, false);
+  });
   app.register(HttpHandlerPlugin);
   const expressApp = express();
   expressApp.get('/proxy', (req, res) => {
     request(`http://localhost:${port}`).pipe(res);
   });
   app.register(HttpHandlerToken, expressApp);
-
-  app.middleware((ctx, next) => {
-    t.equal(ctx.respond, false);
-    return next();
-  });
 
   // $FlowFixMe
   const server = http.createServer(app.callback());

--- a/src/__tests__/express-send.node.js
+++ b/src/__tests__/express-send.node.js
@@ -15,13 +15,9 @@ import {startServer} from '../test-util.js';
 
 test('http handler with express using send', async t => {
   const app = new App('test', () => 'test');
-  app.register(HttpHandlerPlugin);
-  const expressApp = express();
-  expressApp.get('/express', (req, res) => {
-    res.send('OK');
-  });
-  app.register(HttpHandlerToken, expressApp);
-  app.middleware((ctx, next) => {
+
+  app.middleware(async (ctx, next) => {
+    await next();
     if (ctx.url === '/express') {
       t.equal(ctx.res.statusCode, 200, 'express route sets status code');
     } else {
@@ -30,8 +26,13 @@ test('http handler with express using send', async t => {
     // $FlowFixMe
     ctx.req.secure = false;
     ctx.body = 'hit fallthrough';
-    return next();
   });
+  app.register(HttpHandlerPlugin);
+  const expressApp = express();
+  expressApp.get('/express', (req, res) => {
+    res.send('OK');
+  });
+  app.register(HttpHandlerToken, expressApp);
 
   const {server, request} = await startServer(app.callback());
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,6 +6,6 @@
  * @flow
  */
 import type {FusionPlugin} from 'fusion-core';
-import type {DepsType, ServiceType} from './types.js';
+import type {DepsType} from './types.js';
 
-export default ((null: any): FusionPlugin<DepsType, ServiceType>);
+export default ((null: any): FusionPlugin<DepsType, void>);

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@
 import {createPlugin} from 'fusion-core';
 import type {FusionPlugin} from 'fusion-core';
 import {HttpHandlerToken} from './tokens.js';
-import type {DepsType, ServiceType} from './types.js';
+import type {DepsType} from './types.js';
 
 const plugin =
   __NODE__ &&
@@ -42,13 +42,14 @@ const plugin =
             // $FlowFixMe
             res.setHeader = () => {};
             ctx.respond = false;
-            return done();
+            done(null);
           };
           res.on('end', listener);
           res.on('finish', listener);
 
           handler(req, res, error => {
             ctx.res.statusCode = prevStatusCode;
+            // $FlowFixMe
             return done(error);
           });
 
@@ -73,4 +74,4 @@ const plugin =
     },
   });
 
-export default ((plugin: any): FusionPlugin<DepsType, ServiceType>);
+export default ((plugin: any): FusionPlugin<DepsType, void>);

--- a/src/types.js
+++ b/src/types.js
@@ -12,4 +12,4 @@ export type DepsType = {
   handler: typeof HttpHandlerToken,
 };
 
-export type ServiceType = (mixed, mixed, () => Promise<void>) => void;
+export type ServiceType = (mixed, mixed, (error?: any) => Promise<any>) => void;


### PR DESCRIPTION
This will help with interop with other plugins which do things like set cookies or headers in the upstream.