### PR TITLE
Release v0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-http-handler",
   "description": "Allows integration of an existing http handler into the fusion request lifecycle",
-  "version": "0.1.5-1",
+  "version": "0.1.5",
   "repository": "fusionjs/fusion-plugin-http-handler",
   "files": [
     "dist",


### PR DESCRIPTION
- Update handler to run after await next and handle errors from express app ([#67](https://github.com/fusionjs/fusion-plugin-http-handler/pull/67))